### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ EasyLikeArea
 <br>    
 <br>   
    
-##Introduction
+## Introduction
 
 EasyViewProxy is cache manager of EasyLikeArea . The number of the View the default cache is 17.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
